### PR TITLE
Fix clipping on browser resize

### DIFF
--- a/bingo.css
+++ b/bingo.css
@@ -1,37 +1,29 @@
 body {
-	text-align: center;
 	background-color: #575757;
 	color: #272822;
 }
 
-.center {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-}
 
-.center > * {
-	position: absolute;
-	top: 50%;
-	transform: translateY(-50%);
+.title {
+	margin-bottom: -30px;
 }
 
 #bingo {
 	font-family: "Luckiest Guy", cursive;
-	font-size: 150px;
+	font-size: 135px;
 	color: #E74C3C;
 	text-align: center;
 }
 
 #zulu_crew {
 	font-family: "Pacifico", cursive;
-	font-size: 45px;
+	font-size: 40px;
 	color: #F0F7FF;
 	position: relative;
-	top: -55px;
-	left: 160px;
+	top: -48px;
+	left: 145px;
 	transform: rotate(-7deg);
-	margin-bottom: -35px;
+	display: inline-block;
 }
 
 #button {
@@ -42,7 +34,7 @@ body {
 	font-size: 30px;
 	border-radius: 10px;
 	padding: 0px 15px 0px 15px;
-	margin-top: 20px;
+	margin-top: 15px;
 }
 
 #button:hover {
@@ -50,16 +42,17 @@ body {
 }
 
 .bingo_card {
-	border-radius: 25px;
 	display: inline-block;
-	padding: 25px;
+	border-radius: 20px;
+	padding: 20px;
 	background-color: #272822;
+	text-align: center;
+	margin: auto;
 }
 
 #grid {
 	display: table;
-	margin: auto;
-	border-spacing: 5px;
+	border-spacing: 4px;
 }
 
 .row {
@@ -69,9 +62,11 @@ body {
 .space {
 	display: table-cell;
 	position: relative;
+	width: 135px;
+	height: 135px;
+	min-width: 135px;
+	min-height: 135px;
 	vertical-align: middle;
-	width: 150px;
-	height: 150px;
 	background-color: #F0F7FF;
 }
 
@@ -85,7 +80,7 @@ body {
 .content {
 	width: 90%;
 	font-family: 'Roboto', sans-serif;
-	font-size: 16px;
+	font-size: 15px;
 	text-align: center;
 	z-index: 0;
 }

--- a/bingo.js
+++ b/bingo.js
@@ -96,8 +96,23 @@ function GameState(data) {
 	this.__init__();
 }
 
+function center() {
+		var $bingoCard = $(".bingo_card");
+		var top = Math.max(0, ($(window).height() - $bingoCard.outerHeight()) / 2);
+		var left = Math.max(0, ($(window).width() - $bingoCard.outerWidth()) / 2);
+		$bingoCard.css("position", "absolute");
+		$bingoCard.css("top", top + "px");
+		$bingoCard.css("left", left + "px");
+}
+
 $(document).ready(function() {
 	var bingoGrid = new BingoGrid();
+
+	center();
+	$(window).resize(function() {
+		center();
+	});
+
 	$.getJSON("data.json", function(data) {
 		bingoGrid.init(data);
 		$("#button").click(function() {

--- a/data.json
+++ b/data.json
@@ -4,7 +4,6 @@
 	"Big boi",
 	"Burke dies first",
 	"Brutal, savage, rekt",
-	"Caboose says \"I have a death wish\"",
 	"Caboose slow claps",
 	"Door stuck! DOOR STUCK!",
 	"Famous. Last. Words.",
@@ -16,6 +15,7 @@
 	"Hcabe tells us what he's eating",
 	"Hcabe types >10 words in in-game chat",
 	"How could this happen to me? \u266B",
+	"I have a death wish!",
 	"Jac's dogs bark",
 	"Jebaited<br><img src='images/jebaited.png' />",
 	"Kill me fucking money",
@@ -26,6 +26,7 @@
 	"ROOT, stfu!",
 	"Oof!",
 	"Pile of angry",
+	"REEEEEEEEP!",
 	"SeriousPuTTY unloads both barrels of the Boomstick at Jac",
 	"Someone tries to get holy_mori to talk",
 	"studdugie begs for dosh",
@@ -39,5 +40,6 @@
 	"Zoloft says \"oh dear\"",
 	"Waffle and the Eviscerator",
 	"Warheart has to repeat himself because nobody understands his accent",
-	"Warheart speaks with an American accent"
+	"Warheart speaks with an American accent",
+	"Why are you always fucking me?"
 ]

--- a/index.html
+++ b/index.html
@@ -10,13 +10,13 @@
         <script type="text/javascript" src="bingo.js"></script>
     </head>
     <body>
-        <div class="center">
-            <div class="bingo_card">
+        <div class="bingo_card">
+            <div class="title">
                 <div id="bingo">BINGO!</div>
                 <div id="zulu_crew">with the Zulu Crew</div>
-                <div id="grid"></div>
-                <div id="button">Reroll!</div>
             </div>
+            <div id="grid"></div>
+            <div id="button">Reroll!</div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
Redo the way `#bingo_card` is centered so that the top and left sides of the card aren't clipped when the browser is resized.

Also made everything a little smaller and added some new phrases.